### PR TITLE
Fix illegal memory access bug in higher pytorch version

### DIFF
--- a/models/stage_net.py
+++ b/models/stage_net.py
@@ -63,6 +63,7 @@ def balanced_mask_loss_ce(mask, pseudo_gt, gt_labels, ignore_index=255):
     # otherwise, ignore
     weight = pseudo_gt.sum(1).type_as(mask_gt)
     mask_gt += (1 - weight) * ignore_index
+    mask_gt = torch.clamp(mask_gt, max=ignore_index)
 
     # class weight balances the loss w.r.t. number of pixels
     # because we are equally interested in all classes


### PR DESCRIPTION
As many issues have mentioned, higher pytorch version has this bug:
RuntimeError: CUDA error: an illegal memory access was encountered

This is because in code `mask_gt = torch.argmax(pseudo_gt, 1)`, it gets 19 in higher pytorch version if all value in pseudo_gt is zero. So in `mask_gt += (1 - weight) * ignore_index` it will overflow 255. I add a line to avoid overflow so that it will fix this bug in higher pytorch version.
